### PR TITLE
feat: update Go to 1.13.2

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -1,4 +1,4 @@
-# syntax = docker.io/autonomy/bldr:1289eba-frontend
+# syntax = docker.io/autonomy/bldr:v0.1.0-alpha.0-frontend
 
 format: v1alpha2
 

--- a/ca-certificates/pkg.yaml
+++ b/ca-certificates/pkg.yaml
@@ -3,8 +3,8 @@ steps:
 - sources:
   - url: https://curl.haxx.se/ca/cacert.pem
     destination: cacert.pem
-    sha256: 38b6230aa4bee062cd34ee0ff6da173250899642b1937fc130896290b6bd91e3
-    sha512: 527e23d1e83381583cc2efe4625b01a00baa990afc877bb617727e8bffab17a0dc4f36b60162bad375b576ff09bc27acc7e0f095a34150f23d61825b8a7fb81f
+    sha256: 5cd8052fcf548ba7e08899d8458a32942bf70450c9af67a0850b4c711804a2e4
+    sha512: 49778472e46ce3b86b3930f4df5731ac86daf4d8602d418af1c89dc35df5f98c4557aa6c6eb280558c61139ead4b96cbb457a259f72640452f28a2fecd4ccb89
   install:
   - |
     mkdir -p /rootfs${TOOLCHAIN}/etc/ssl/certs

--- a/golang/golang/pkg.yaml
+++ b/golang/golang/pkg.yaml
@@ -4,10 +4,10 @@ dependencies:
   - stage: golang-bootstrap
 steps:
   - sources:
-      - url: https://dl.google.com/go/go1.13.1.src.tar.gz
+      - url: https://dl.google.com/go/go1.13.2.src.tar.gz
         destination: go.src.tar.gz
-        sha256: 81f154e69544b9fa92b1475ff5f11e64270260d46e7e36c34aafc8bc96209358
-        sha512: 696fc735271bd76ae59c5015c8efa52121243257f4ffcc1460fd79cf9a5e167db0b30d04137ec71a8789742673c2288bd62d55b546c2d2b2a05e8b3669af8616
+        sha256: 1ea68e01472e4276526902b8817abd65cf84ed921977266f0c11968d5e915f44
+        sha512: 2741ccbb13abf69cbb575145c65fc9f3c422692009d6bf6e991f6d6e3ddfed94374b242deb5fffbe4a22f64c3734cc7dba0b1438c24ae295eecef2b515504892
 
     env:
       GOROOT_BOOTSTRAP: '{{ .TOOLCHAIN }}/go_bootstrap'


### PR DESCRIPTION
This release contains two security fixes.

Also bump shebang version of bldr to the release tag.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>