### PR TITLE
chore: bump toolchain image for toolchain refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ endif
 
 COMMON_ARGS = --progress=auto
 COMMON_ARGS += --frontend=dockerfile.v0
-COMMON_ARGS += --allow security.insecure
 COMMON_ARGS += --local context=.
 COMMON_ARGS += --local dockerfile=.
 COMMON_ARGS += --opt filename=Pkgfile
@@ -74,8 +73,7 @@ ifneq ($(BUILDKIT_CONTAINER_RUNNING),$(BUILDKIT_CONTAINER_NAME))
 		--privileged \
 		-p 1234:1234 \
 		$(BUILDKIT_IMAGE) \
-		--addr $(BUILDKIT_HOST) \
-		--allow-insecure-entitlement security.insecure
+		--addr $(BUILDKIT_HOST)
 	@echo "Wait for buildkitd to become available"
 	@sleep 5
 endif

--- a/Pkgfile
+++ b/Pkgfile
@@ -3,4 +3,4 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: docker.io/autonomy/toolchain:0714f82
+  TOOLCHAIN_IMAGE: docker.io/autonomy/toolchain:52e8abf


### PR DESCRIPTION
See https://github.com/talos-systems/toolchain/pull/8

Also removes insecure entitlement from Makefile (copy-paste bug).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>