### PR TITLE
chore: add 'img' tool

### DIFF
--- a/curl/pkg.yaml
+++ b/curl/pkg.yaml
@@ -2,6 +2,7 @@ name: curl
 dependencies:
   - stage: base
   - stage: libressl
+    runtime: true
   - stage: zlib
   - stage: pkg-config
 steps:

--- a/git/pkg.yaml
+++ b/git/pkg.yaml
@@ -6,6 +6,7 @@ dependencies:
   - stage: gettext
   - stage: libressl
   - stage: curl
+    runtime: true
   - stage: autoconf
 steps:
   - sources:

--- a/img/pkg.yaml
+++ b/img/pkg.yaml
@@ -1,0 +1,40 @@
+name: img
+dependencies:
+  - stage: base
+  - stage: ca-certificates
+  - stage: golang
+  - stage: make
+  - stage: git
+  - stage: pkg-config
+  - stage: libseccomp
+steps:
+  - env:
+      GO111MODULE: off
+      GOPATH: /go
+      PKGPATH: src/github.com/genuinetools/img
+      CGO_ENABLED: "1"
+    sources:
+      - url: https://github.com/genuinetools/img/archive/9856fcb98e30a8152a7f5f1445bb3ecc11598e75.tar.gz
+        destination: img.tar.gz
+        sha256: 73756b8d6d27d665ceeac8ae06678be477c53a832db2e2e24171672e46811442
+        sha512: bd18a8a83c6f99d63f7e520660ac772cbe80cc2281b71a18f71f447e8f6018f17c31c34143c7d7138e18b8d97a1ff6f70eb1b22f153b962f5ae2ba40778ea182
+    prepare:
+      - |
+        mkdir -p ${GOPATH}/${PKGPATH}
+        tar -xzf img.tar.gz --strip-components=1 -C ${GOPATH}/${PKGPATH}
+    build:
+      - |
+        export PATH=${GOPATH}/bin:${TOOLCHAIN}/go/bin:${PATH}
+        cd ${GOPATH}/${PKGPATH}
+        go get github.com/go-bindata/go-bindata/...
+        make
+    install:
+      - |
+        cd ${GOPATH}/${PKGPATH}
+        export PATH=${GOPATH}/bin:${TOOLCHAIN}/go/bin:${PATH}
+        make install
+        mkdir -p /rootfs${TOOLCHAIN}/bin
+        mv ${GOPATH}/bin/img /rootfs${TOOLCHAIN}/bin
+finalize:
+  - from: /rootfs
+    to: /

--- a/libseccomp/pkg.yaml
+++ b/libseccomp/pkg.yaml
@@ -1,0 +1,29 @@
+name: libseccomp
+dependencies:
+  - stage: base
+steps:
+  - sources:
+      - url: https://github.com/seccomp/libseccomp/releases/download/v2.4.2/libseccomp-2.4.2.tar.gz
+        destination: libseccomp.tar.gz
+        sha256: b54f27b53884caacc932e75e6b44304ac83586e2abe7a83eca6daecc5440585b
+        sha512: 375a3c7c658be6a08b9bb30963e10bb49e8e066119e0be6d3d97faac3db18b8e2c6938d8b5d3874b2f5331ec8295170112fbae83b5a3b5a5bebc0d6705bdfdbb
+    prepare:
+      - |
+        tar -xzf libseccomp.tar.gz --strip-components=1
+
+        mkdir build
+        cd build
+
+        ../configure \
+            --prefix=/${TOOLCHAIN}
+    build:
+      - |
+        cd build
+        make -j $(nproc)
+    install:
+      - |
+        cd build
+        make install DESTDIR=/rootfs
+finalize:
+  - from: /rootfs
+    to: /

--- a/tools/pkg.yaml
+++ b/tools/pkg.yaml
@@ -29,6 +29,7 @@ dependencies:
   - stage: gperf
   - stage: grep
   - stage: gzip
+  - stage: img
   - stage: kmod
   - stage: libressl
   - stage: libtool


### PR DESCRIPTION
`img` allows to build docker images inside the buildkit context which
will be used in Talos build to build app container images inside
buildkit, making sure buildkit is able to track all the dependencies.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>