### PR TITLE
feat: upgrade Go to 1.14.2

### DIFF
--- a/golang/golang/pkg.yaml
+++ b/golang/golang/pkg.yaml
@@ -4,10 +4,10 @@ dependencies:
   - stage: golang-bootstrap
 steps:
   - sources:
-      - url: https://dl.google.com/go/go1.14.1.src.tar.gz
+      - url: https://dl.google.com/go/go1.14.2.src.tar.gz
         destination: go.src.tar.gz
-        sha256: 2ad2572115b0d1b4cb4c138e6b3a31cee6294cb48af75ee86bec3dca04507676
-        sha512: f0112fbf984e2764cd90d42b2f844b986b421adf8bf68551cccefeb320db7f3490ab1532f770f20c943c68c7185ce139c8248991adb0529527358ffdc8047ad9
+        sha256: 98de84e69726a66da7b4e58eac41b99cbe274d7e8906eeb8a5b7eb0aadee7f7c
+        sha512: 3f6804e1a60df6a7c55c294fe4147b2d6f028c619ad4ae5b1ae8793c6be637a1e6a62721cc7ce0b28918ab3441a89fa9acda72cb5450bf5af8d7872411d28015
 
     env:
       GOROOT_BOOTSTRAP: '{{ .TOOLCHAIN }}/go_bootstrap'


### PR DESCRIPTION
Looks like there're some fixes for potential deadlocks:
https://github.com/golang/go/issues?q=milestone%3AGo1.14.2+label%3ACherryPickApproved

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>