### PR TITLE
feat: provide Go bootstrap on arm64

### DIFF
--- a/golang/alpine/pkg.yaml
+++ b/golang/alpine/pkg.yaml
@@ -1,0 +1,16 @@
+name: golang-alpine
+dependencies:
+  - stage: base
+install:
+  - go
+steps:
+  - env:
+      GOROOT_FINAL: '{{ .TOOLCHAIN }}/go_bootstrap'
+
+    install:
+      - mkdir -p "/rootfs${GOROOT_FINAL}"
+      - cp -r /usr/lib/go/* "/rootfs${GOROOT_FINAL}"
+
+finalize:
+  - from: /rootfs
+    to: /

--- a/golang/golang/pkg.yaml
+++ b/golang/golang/pkg.yaml
@@ -1,7 +1,7 @@
 name: golang
 dependencies:
   - stage: base
-  - stage: golang-bootstrap
+  - stage: '{{ if eq .ARCH "aarch64" }}golang-alpine{{ else }}golang-bootstrap{{ end }}'
 steps:
   - sources:
       - url: https://dl.google.com/go/go1.14.3.src.tar.gz


### PR DESCRIPTION
As Go 1.4 didn't support ARM architecture, we can't use that to
bootstrap Go compiler on arm64. So instead use Alpine's Go package as
bootstrap to build our Go compiler.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>