### PR TITLE
fix: build "full" gettext

### DIFF
--- a/gettext/pkg.yaml
+++ b/gettext/pkg.yaml
@@ -15,20 +15,16 @@ steps:
         EMACS="no" ../gettext-tools/configure \
             --prefix=${TOOLCHAIN} \
             --enable-relocatable \
-            --disable-shared
+            --disable-shared \
+            --disable-java
     build:
       - |
         cd build
-        make -C gnulib-lib -j $(nproc)
-        make -C intl pluralx.c -j $(nproc)
-        make -C src msgfmt -j $(nproc)
-        make -C src msgmerge -j $(nproc)
-        make -C src xgettext -j $(nproc)
+        make -j $(nproc)
     install:
       - |
         cd build
-        mkdir -p /rootfs${TOOLCHAIN}/bin
-        cp -v src/{msgfmt,msgmerge,xgettext} /rootfs${TOOLCHAIN}/bin
+        make install DESTDIR=/rootfs
 finalize:
   - from: /rootfs
     to: /

--- a/squashfs-tools/pkg.yaml
+++ b/squashfs-tools/pkg.yaml
@@ -6,7 +6,7 @@ dependencies:
   - stage: patch
 steps:
   - sources:
-      - url: https://downloads.sourceforge.net/project/squashfs/squashfs/squashfs4.3/squashfs4.3.tar.gz
+      - url: https://mirror.us.leaseweb.net/slackware/slackware64-14.2/source/ap/squashfs-tools/squashfs4.3.tar.gz
         destination: squashfs.tar.gz
         sha256: 0d605512437b1eb800b4736791559295ee5f60177e102e4d4ccd0ee241a5f3f6
         sha512: 854ed7acc99920f24ecf11e0da807e5a2a162eeda55db971aba63a03f0da2c13b20ec0564a906c4b0e415bd8258b273a10208c7abc0704f2ceea773aa6148a79

--- a/swig/pkg.yaml
+++ b/swig/pkg.yaml
@@ -5,7 +5,7 @@ dependencies:
   - stage: pcre
 steps:
   - sources:
-      - url: https://downloads.sourceforge.net/project/swig/swig/swig-4.0.0/swig-4.0.0.tar.gz
+      - url: https://ftp.osuosl.org/pub/blfs/conglomeration/swig/swig-4.0.0.tar.gz
         destination: swig.tar.gz
         sha256: e8a39cd6437e342cdcbd5af27a9bf11b62dc9efec9248065debcb8276fcbb925
         sha512: c897b87fb8b21caf8d1bee2c39cb9675a3b0ee047110e808c310a2787f8b89585738726e9f517c64e9d2f1b8311136365c569528f399b444b1081f69689b7165


### PR DESCRIPTION
Some programs need `autopoint` for `autoreconf` to work correctly.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>