### PR TITLE
chore: enforce resources on Drone steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,10 @@ steps:
     environment:
       SSH_KEY:
         from_secret: ssh_key
+    resources:
+      requests:
+        cpu: 24000
+        memory: 48GiB
     volumes:
       - name: docker-socket
         path: /var/run


### PR DESCRIPTION
This should allow only one build of `tools` per node.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>