### PR TITLE
feat: upgrade Make to 4.3

### DIFF
--- a/make/pkg.yaml
+++ b/make/pkg.yaml
@@ -5,10 +5,10 @@ dependencies:
   - image: "{{ .TOOLCHAIN_IMAGE }}"
 steps:
   - sources:
-      - url: https://ftp.gnu.org/gnu/make/make-4.2.1.tar.gz
+      - url: https://ftp.gnu.org/gnu/make/make-4.3.tar.gz
         destination: make.tar.gz
-        sha256: e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7
-        sha512: d5f6ce3ac7c9a55cf8c1c04afa7d967dd311c9bb3167275ebb2649cf144f3740cf08450dc010a6acdea1fd529fd528a50b3c3381f4c9a7e83ec59b761817a038
+        sha256: e05fdde47c5f7ca45cb697e973894ff4f5d79e13b750ed57d7b66d8defc78e19
+        sha512: 9a1185cc468368f4ec06478b1cfa343bf90b5cd7c92c0536567db0315b0ee909af53ecce3d44cfd93dd137dbca1ed13af5713e8663590c4fdd21ea635d78496b
     prepare:
       - |
         tar -xzf make.tar.gz --strip-components=1


### PR DESCRIPTION
This might have some bugs fixed related to kernel pipe usage and high
`-j` number.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>