### PR TITLE
feat: add gcc math libs for gcc plugins support

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/talos-systems/toolchain:v0.1.0-9-g4489575
+  TOOLCHAIN_IMAGE: ghcr.io/talos-systems/toolchain:v0.1.0-10-ge152e38
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/tools

--- a/gmp/pkg.yaml
+++ b/gmp/pkg.yaml
@@ -1,0 +1,29 @@
+name: gmp
+dependencies:
+  - stage: base
+  - stage: m4
+steps:
+  - sources:
+      - url: https://ftp.gnu.org/gnu/gmp/gmp-6.2.0.tar.xz
+        destination: gmp.tar.xz
+        sha256: 258e6cd51b3fbdfc185c716d55f82c08aff57df0c6fbd143cf6ed561267a1526
+        sha512: a066f0456f0314a1359f553c49fc2587e484ff8ac390ff88537266a146ea373f97a1c0ba24608bf6756f4eab11c9056f103c8deb99e5b57741b4f7f0ec44b90c
+    prepare:
+      - |
+        tar -xJf gmp.tar.xz --strip-components=1
+        mkdir build
+        cd build
+        ../configure \
+            --prefix=${TOOLCHAIN} \
+            --disable-static
+    build:
+      - |
+        cd build
+        make -j $(nproc)
+    install:
+      - |
+        cd build
+        make install DESTDIR=/rootfs
+finalize:
+  - from: /rootfs
+    to: /

--- a/mpc/pkg.yaml
+++ b/mpc/pkg.yaml
@@ -1,0 +1,30 @@
+name: mpc
+dependencies:
+  - stage: base
+  - stage: gmp
+  - stage: mpfr
+steps:
+  - sources:
+      - url: https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
+        destination: mpc.tar.gz
+        sha256: 6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e
+        sha512: 72d657958b07c7812dc9c7cbae093118ce0e454c68a585bfb0e2fa559f1bf7c5f49b93906f580ab3f1073e5b595d23c6494d4d76b765d16dde857a18dd239628
+    prepare:
+      - |
+        tar -xzf mpc.tar.gz --strip-components=1
+        mkdir build
+        cd build
+        ../configure \
+            --prefix=${TOOLCHAIN} \
+            --disable-static
+    build:
+      - |
+        cd build
+        make -j $(nproc)
+    install:
+      - |
+        cd build
+        make install DESTDIR=/rootfs
+finalize:
+  - from: /rootfs
+    to: /

--- a/mpfr/pkg.yaml
+++ b/mpfr/pkg.yaml
@@ -1,0 +1,30 @@
+name: mpfr
+dependencies:
+  - stage: base
+  - stage: gmp
+steps:
+  - sources:
+      - url: https://ftp.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.xz
+        destination: mpfr.tar.xz
+        sha256: 1d3be708604eae0e42d578ba93b390c2a145f17743a744d8f3f8c2ad5855a38a
+        sha512: d583555d08863bf36c89b289ae26bae353d9a31f08ee3894520992d2c26e5683c4c9c193d7ad139632f71c0a476d85ea76182702a98bf08dde7b6f65a54f8b88
+    prepare:
+      - |
+        tar -xJf mpfr.tar.xz --strip-components=1
+        mkdir build
+        cd build
+        ../configure \
+            --prefix=${TOOLCHAIN} \
+            --enable-thread-safe \
+            --disable-static
+    build:
+      - |
+        cd build
+        make -j $(nproc)
+    install:
+      - |
+        cd build
+        make install DESTDIR=/rootfs
+finalize:
+  - from: /rootfs
+    to: /

--- a/tools/pkg.yaml
+++ b/tools/pkg.yaml
@@ -27,6 +27,7 @@ dependencies:
   - stage: gawk
   - stage: gettext
   - stage: git
+  - stage: gmp
   - stage: golang
   - stage: gperf
   - stage: grep
@@ -38,6 +39,8 @@ dependencies:
   - stage: libuv
   - stage: m4
   - stage: make
+  - stage: mpc
+  - stage: mpfr
   - stage: musl-fts
   - stage: musl-obstack
   - stage: ncurses


### PR DESCRIPTION
These libs are used to build gcc in `toolchain`, but as GCC plugins are
built as part of the kernel build, they are required once again. These
builds mirror versions from the toolchain.

Bump toolchain for gcc plugin support.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>