### PR TITLE
feat: bump toolchain for libmusl CVE-2020-28928 fix

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/talos-systems/toolchain:v0.1.0-10-ge152e38
+  TOOLCHAIN_IMAGE: ghcr.io/talos-systems/toolchain:v0.1.0-12-g78df21c
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/tools

--- a/libseccomp/pkg.yaml
+++ b/libseccomp/pkg.yaml
@@ -3,10 +3,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://github.com/seccomp/libseccomp/releases/download/v2.4.2/libseccomp-2.4.2.tar.gz
+      - url: https://github.com/seccomp/libseccomp/releases/download/v2.4.4/libseccomp-2.4.4.tar.gz
         destination: libseccomp.tar.gz
-        sha256: b54f27b53884caacc932e75e6b44304ac83586e2abe7a83eca6daecc5440585b
-        sha512: 375a3c7c658be6a08b9bb30963e10bb49e8e066119e0be6d3d97faac3db18b8e2c6938d8b5d3874b2f5331ec8295170112fbae83b5a3b5a5bebc0d6705bdfdbb
+        sha256: 4e79738d1ef3c9b7ca9769f1f8b8d84fc17143c2c1c432e53b9c64787e0ff3eb
+        sha512: 53e5aa338a1c30ce826551e33be6ef877af43b1d8cfd2e1b6ffb70789eb2070d2610fb7cb5cec4a3a4c4a1221767f867f3d2bc07b6b1d9742719b1e053630b24
     prepare:
       - |
         tar -xzf libseccomp.tar.gz --strip-components=1


### PR DESCRIPTION
This brings in musl 1.2.2.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>