### PR TITLE
feat: upgrade Python 3.9.2, enable pip

### DIFF
--- a/python3/pkg.yaml
+++ b/python3/pkg.yaml
@@ -4,10 +4,10 @@ dependencies:
   - stage: zlib
 steps:
   - sources:
-      - url: https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
+      - url: https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tar.xz
         destination: python.tar.xz
-        sha256: 9c73e63c99855709b9be0b3cc9e5b072cb60f37311e8c4e50f15576a0bf82854
-        sha512: b141039c9701a8cb0d15cd11a279153077524af4d0599e7d2c7279d4c18d05fda06b33ef82342d875de996c7117b7dc6eb154dc3669d38a1efa99801aeec6c5e
+        sha256: 3c2034c54f811448f516668dce09d24008a0716c3a794dd8639b5388cbde247d
+        sha512: b204d865e4c974951830008c381678876987da267c37bce3b4e488c07aa744658e57b8dc5d248051d0391f3b580e69877f7772abc0a0de5288349d448ccf0789
     prepare:
       - |
         tar -xJf python.tar.xz --strip-components=1
@@ -19,7 +19,7 @@ steps:
 
         ../configure \
             --prefix=${TOOLCHAIN} \
-            --with-ensurepip=no
+            --with-ensurepip=install
     build:
       - |
         cd build


### PR DESCRIPTION
New release of `u-boot` relies on `pkg_resources` module (part of
`setuptools`), so bootstrap Python with pip to include `pkg_resources`
as well.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>