### PR TITLE
feat: bump protobuf deps, add protoc-gen-go-grpc

### DIFF
--- a/protobuf/pkg.yaml
+++ b/protobuf/pkg.yaml
@@ -4,10 +4,10 @@ dependencies:
   - stage: patch
 steps:
   - sources:
-      - url: https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protobuf-cpp-3.14.0.tar.gz
+      - url: https://github.com/protocolbuffers/protobuf/releases/download/v3.15.3/protobuf-cpp-3.15.3.tar.gz
         destination: protobuf-cpp.tar.gz
-        sha256: 50ec5a07c0c55d4ec536dd49021f2e194a26bfdbc531d03d1e9d4d3e27175659
-        sha512: 021a377a2bcfb1ee540e49371d1d7297d77359fd0de7b4a079918e8580258a7ee14256a9b392853dc6744e88d63b2fae723ab61cc9af599828f07f48b0161c74
+        sha256: 984a65bcc3522b40b7aa493e392dc7ff710c2e4254fdd3ca0594a16f32391199
+        sha512: 09d6442b4c20a108cee8d305f815bf809b68f1dd4149cc6a9e17477c3e80747f8672038184b2ca5fc3994a94f32f5d2162335893bcd90ca241b8e330ec1ce6b3
     prepare:
       - |
         tar -xzf protobuf-cpp.tar.gz --strip-components=1

--- a/protoc-gen-go-grpc/pkg.yaml
+++ b/protoc-gen-go-grpc/pkg.yaml
@@ -1,0 +1,26 @@
+name: protoc-gen-go-grpc
+dependencies:
+  - stage: base
+  - stage: golang
+steps:
+  - sources:
+      - url: https://github.com/grpc/grpc-go/archive/v1.36.0.tar.gz
+        destination: grpc-go.tar.gz
+        sha256: d460c8f379ff240f6169924ec399080351e4a03a0492fbb5a761f4e2d14d4fda
+        sha512: da566806154d6a79c8e2c06f44a6b3ee68b79e328df471ec6ef003c7a326667e299c3c545a6849c5b5d6a8d4b7ff6f9d59ae9243bfe0491ecdd77c4a95cbb453
+    prepare:
+      - |
+        tar -xzf grpc-go.tar.gz --strip-components=1
+    build:
+      - |
+        export PATH=${TOOLCHAIN}/go/bin:${PATH}
+        export GO111MODULE=on
+        cd cmd/protoc-gen-go-grpc
+        go build .
+    install:
+      - |
+        mkdir -p /rootfs${TOOLCHAIN}/bin
+        mv cmd/protoc-gen-go-grpc/protoc-gen-go-grpc /rootfs${TOOLCHAIN}/bin
+finalize:
+  - from: /rootfs
+    to: /

--- a/protoc-gen-go/pkg.yaml
+++ b/protoc-gen-go/pkg.yaml
@@ -4,27 +4,23 @@ dependencies:
   - stage: golang
 steps:
   - sources:
-      # We have to use github.com/golang/protobuf/protoc-gen-go instead of
-      # google.golang.org/protobuf/cmd/protoc-gen-go (see https://github.com/golang/protobuf/issues/1070)
-      # because the latter package was introduced in grpc-go v1.30,
-      # but upgrading grpc-go is not easy due to https://github.com/etcd-io/etcd/issues/12124.
-      - url: https://github.com/golang/protobuf/archive/v1.4.3.tar.gz
-        destination: golang-protobuf.tar.gz
-        sha256: 5736f943f8647362f5559689df6154f3c85d261fb088867c8a68494e2a767610
-        sha512: e8d4cb5bd4e10436db137ca1c53eb75c8e5c9637863a1d29e960f2e52505097da93a153b00ba5e0dc6fc355490cd51e185e861682fc1ce75bf56d6cd032366ee
+      - url: https://github.com/protocolbuffers/protobuf-go/archive/v1.25.0.tar.gz
+        destination: protobuf-go.tar.gz
+        sha256: c1c04d6e36c0d0fb6f3374197f9025d7e6df13f38a974098be020617c00fbaf2
+        sha512: f5e4c2399174ae41d73f902b189f792a22856e88cfdf2c09a9f39871179f2e937d2de24a46fc5e95b6c3870fab17d832480b95be49d27d8664ec2e0a4706cf3b
     prepare:
       - |
-        tar -xzf golang-protobuf.tar.gz --strip-components=1
+        tar -xzf protobuf-go.tar.gz --strip-components=1
     build:
       - |
         export PATH=${TOOLCHAIN}/go/bin:${PATH}
         export GO111MODULE=on
-        cd protoc-gen-go
+        cd cmd/protoc-gen-go
         go build .
     install:
       - |
         mkdir -p /rootfs${TOOLCHAIN}/bin
-        mv protoc-gen-go/protoc-gen-go /rootfs${TOOLCHAIN}/bin
+        mv cmd/protoc-gen-go/protoc-gen-go /rootfs${TOOLCHAIN}/bin
 finalize:
   - from: /rootfs
     to: /

--- a/tools/pkg.yaml
+++ b/tools/pkg.yaml
@@ -50,6 +50,7 @@ dependencies:
   - stage: pkg-config
   - stage: protobuf
   - stage: protoc-gen-go
+  - stage: protoc-gen-go-grpc
   - stage: python2
   - stage: python3
   - stage: rhash


### PR DESCRIPTION
See https://github.com/golang/protobuf/issues/1070

Before this one is merged, Talos build should be updated.

`ghcr.io/aleksi/tools:v0.3.0-23-g00e42a3`