### PR TITLE
chore: bump tools to 0.2.0

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/talos-systems/toolchain:v0.1.0-12-g78df21c
+  TOOLCHAIN_IMAGE: ghcr.io/talos-systems/toolchain:v0.2.0
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/tools


### PR DESCRIPTION
No-op, just tag updates (same toolchain contents).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>