### PR TITLE
chore: bump Go to 1.16.2

### DIFF
--- a/golang/golang/pkg.yaml
+++ b/golang/golang/pkg.yaml
@@ -4,10 +4,10 @@ dependencies:
   - stage: '{{ if eq .ARCH "aarch64" }}golang-alpine{{ else }}golang-bootstrap{{ end }}'
 steps:
   - sources:
-      - url: https://dl.google.com/go/go1.16.1.src.tar.gz
+      - url: https://dl.google.com/go/go1.16.2.src.tar.gz
         destination: go.src.tar.gz
-        sha256: 680a500cd8048750121677dd4dc055fdfd680ae83edc7ed60a4b927e466228eb
-        sha512: c7674be1a4a03c031d13a52e03a5e134bd2f499fe1bde3083885e363528252fce43b119974b804c8c46ec59e85337bb94e96b7a7183bdb78301898e222b3bba1
+        sha256: 37ca14287a23cb8ba2ac3f5c3dd8adbc1f7a54b9701a57824bf19a0b271f83ea
+        sha512: d14858a75cc7411975aaca705e66145287dc96b4fac1b1b06b95377dc5e5d2762f060973744114f42c780b34ea4baef7038c94616649c2dcc5c97e261cefc6bd
 
     env:
       GOROOT_BOOTSTRAP: '{{ .TOOLCHAIN }}/go_bootstrap'


### PR DESCRIPTION
go1.16.2 (released 2021/03/11) includes fixes to cgo, the compiler, linker, the go command, and the syscall and time packages.
See the Go 1.16.2 milestone on our issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.16.2+label%3ACherryPickApproved
