### PR TITLE
feat: bump protobuf-related tools

### DIFF
--- a/protobuf/pkg.yaml
+++ b/protobuf/pkg.yaml
@@ -4,10 +4,10 @@ dependencies:
   - stage: patch
 steps:
   - sources:
-      - url: https://github.com/protocolbuffers/protobuf/releases/download/v3.15.3/protobuf-cpp-3.15.3.tar.gz
+      - url: https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protobuf-cpp-3.15.6.tar.gz
         destination: protobuf-cpp.tar.gz
-        sha256: 984a65bcc3522b40b7aa493e392dc7ff710c2e4254fdd3ca0594a16f32391199
-        sha512: 09d6442b4c20a108cee8d305f815bf809b68f1dd4149cc6a9e17477c3e80747f8672038184b2ca5fc3994a94f32f5d2162335893bcd90ca241b8e330ec1ce6b3
+        sha256: bbdfb7455431d7d58666e8a2996d14b236718ff238eecde10646581e4c87f168
+        sha512: e41d687351ee7ad38e83e5e952ca53e44d8e8b02242ea6fcf218960e5409921ddd5ee0588dfcf9485b425d3711bb060d3f61129900b952fda368008e13cb3830
     prepare:
       - |
         tar -xzf protobuf-cpp.tar.gz --strip-components=1

--- a/protoc-gen-go/pkg.yaml
+++ b/protoc-gen-go/pkg.yaml
@@ -4,10 +4,10 @@ dependencies:
   - stage: golang
 steps:
   - sources:
-      - url: https://github.com/protocolbuffers/protobuf-go/archive/v1.25.0.tar.gz
+      - url: https://github.com/protocolbuffers/protobuf-go/archive/v1.26.0.tar.gz
         destination: protobuf-go.tar.gz
-        sha256: c1c04d6e36c0d0fb6f3374197f9025d7e6df13f38a974098be020617c00fbaf2
-        sha512: f5e4c2399174ae41d73f902b189f792a22856e88cfdf2c09a9f39871179f2e937d2de24a46fc5e95b6c3870fab17d832480b95be49d27d8664ec2e0a4706cf3b
+        sha256: 26218474bcf776ecf32d7d194c6bfaca8e7b4f0c087e5b595fd50fbb31409676
+        sha512: 18d3392fae131014e95961cc7490c8a4f0e0a7d95a18f0a469a9f2b119a1b89bf1952881950129e2b96ea4096b220ff8a3250736ca6efd5eca004f56db861844
     prepare:
       - |
         tar -xzf protobuf-go.tar.gz --strip-components=1


### PR DESCRIPTION
protoc: 3.15.6

protoc-gen-go: 1.26.0

See also talos-systems/talos#3342

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>