### PR TITLE
chore: update musl

### DIFF
--- a/musl-fts/pkg.yaml
+++ b/musl-fts/pkg.yaml
@@ -8,7 +8,7 @@ dependencies:
   - stage: pkg-config
 steps:
   - sources:
-      - url: https://github.com/pullmoll/musl-fts/archive/v1.2.7/musl-fts-1.2.7.tar.gz
+      - url: https://github.com/void-linux/musl-fts/archive/refs/tags/v1.2.7.tar.gz
         destination: musl-fts.tar.gz
         sha256: 49ae567a96dbab22823d045ffebe0d6b14b9b799925e9ca9274d47d26ff482a6
         sha512: 949f73b9406b06bd8712c721b4ec89afcb37d4eaef5666cccf3712242d3a57fc0acf3ca994934e0f57c1e92f40521a9370132a21eb6d1957415a83c76bf20feb

--- a/musl-obstack/pkg.yaml
+++ b/musl-obstack/pkg.yaml
@@ -7,10 +7,10 @@ dependencies:
   - stage: pkg-config
 steps:
   - sources:
-      - url: https://github.com/pullmoll/musl-obstack/archive/v1.1/musl-obstack-1.1.tar.gz
+      - url: https://github.com/void-linux/musl-obstack/archive/refs/tags/v1.2.2.tar.gz
         destination: musl-obstack.tar.gz
-        sha256: 52a216613e7d55e8725e43d017bb2d49a4b1ffa1e06da472f03c7f9875df7d0d
-        sha512: e3a9956133d72a00663cf8d9720e62002142e113e7d67e2338a2bce1bdfac9eefd4290db8add15eabafdf01065f7fe9bb6754faa36b88df819c53d44fa140757
+        sha256: 6eac88961c58a53f31cccd719b97d1b33c65436c51664e760a9582e2659c1314
+        sha512: 61ac90d8878ea620a5bab3ea8be1f8e42d26040475609f5a389a68b2dc0cfb4a10084deb994568392e5671b8ba405e9e78eb7e6313d03afbbcdde82d2e7995b0
     prepare:
       - |
         tar -xzf musl-obstack.tar.gz --strip-components=1


### PR DESCRIPTION
Switch musl-fts repo back to upstream.
Update musl-obstack to 1.2.2:
* https://github.com/void-linux/musl-obstack/releases/tag/v1.2
* https://github.com/void-linux/musl-obstack/releases/tag/v1.2.1
* https://github.com/void-linux/musl-obstack/releases/tag/v1.2.2

Signed-off-by: Alexey Palazhchenko <alexey.palazhchenko@gmail.com>