### PR TITLE
chore: add patch dependency

### DIFF
--- a/cpio/pkg.yaml
+++ b/cpio/pkg.yaml
@@ -2,6 +2,7 @@ name: cpio
 dependencies:
   - stage: base
   - stage: autoconf
+  - stage: patch
 steps:
   - sources:
       - url: https://ftp.gnu.org/gnu/cpio/cpio-2.13.tar.gz

--- a/perl/pkg.yaml
+++ b/perl/pkg.yaml
@@ -1,6 +1,7 @@
 name: perl
 dependencies:
   - stage: base
+  - stage: patch
 steps:
   - sources:
       - url: https://www.cpan.org/src/5.0/perl-5.28.2.tar.xz

--- a/rhash/pkg.yaml
+++ b/rhash/pkg.yaml
@@ -2,6 +2,7 @@ name: rhash
 dependencies:
   - stage: base
   - stage: libressl
+  - stage: patch
 steps:
   - sources:
       - url: http://deb.debian.org/debian/pool/main/r/rhash/rhash_1.4.1.orig.tar.gz

--- a/tar/pkg.yaml
+++ b/tar/pkg.yaml
@@ -1,6 +1,7 @@
 name: tar
 dependencies:
   - stage: base
+  - stage: patch
 steps:
   - sources:
       - url: https://ftp.gnu.org/gnu/tar/tar-1.30.tar.xz


### PR DESCRIPTION
Add dependency on `patch` where it was missing. ~Not really know how it builds
right now without this though.~

This is required as new alpine base image (which is with new bldr version), doesn't have `patch` in the base image.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>