### PR TITLE
chore: update bldr with new version

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -1,4 +1,4 @@
-# syntax = ghcr.io/talos-systems/bldr:v0.2.0-alpha.3-frontend
+# syntax = ghcr.io/talos-systems/bldr:v0.2.0-alpha.5-frontend
 
 # Sync bldr image with Makefile
 


### PR DESCRIPTION
This pulls in optimized flow and also bumps alpine to 3.14.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>