### PR TITLE
feat: update protobuf to 3.19.1, grpc-go to 1.42.0

### DIFF
--- a/protobuf/pkg.yaml
+++ b/protobuf/pkg.yaml
@@ -3,10 +3,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protobuf-cpp-3.17.3.tar.gz
+      - url: https://github.com/protocolbuffers/protobuf/releases/download/v3.19.1/protobuf-cpp-3.19.1.tar.gz
         destination: protobuf-cpp.tar.gz
-        sha256: 51cec99f108b83422b7af1170afd7aeb2dd77d2bcbb7b6bad1f92509e9ccf8cb
-        sha512: efad397f5cdda6639d5e9980fe6eeadc1ef768bf1d96b1e528a1d7ba1d81ceb49e22cbd78d9b4ab3518236055140568342ff138204b4a47234fb2957a89d2db8
+        sha256: 645192532f28254152b51c01868efdf9b766b1dbe49c77cccd6efcdb2d7c7bc2
+        sha512: e02185e26887da5de76d6bf446ec693df865ed454c6b4b2c80e936b7c8a837e79f2e34df874d72d818118b17169adbb386b0cbc95242d225e657b0945da4cc1d
     prepare:
       - |
         tar -xzf protobuf-cpp.tar.gz --strip-components=1

--- a/protoc-gen-go-grpc/pkg.yaml
+++ b/protoc-gen-go-grpc/pkg.yaml
@@ -4,10 +4,10 @@ dependencies:
   - stage: golang
 steps:
   - sources:
-      - url: https://github.com/grpc/grpc-go/archive/refs/tags/v1.39.1.tar.gz
+      - url: https://github.com/grpc/grpc-go/archive/refs/tags/v1.42.0.tar.gz
         destination: grpc-go.tar.gz
-        sha256: 5c08d70fa32bebc917f1b684d60281d15d2dd7f8a7f5992710f7a2257304fcba
-        sha512: 0019f3d64ca4982978d125b8387987856abea2173845bbcf07c606a66abf98e784c2a734d62e8cb10e7760f5ae0c6acaaa486af7088521cfdc5b3266abe2d64c
+        sha256: fb3cca7bd67fe2dfd614b5f51917c33c82fa0d0b646c1397d8b97db65a14f17a
+        sha512: ff22842854ef4b3cfd842b344f3ac3641a815e1383b86fee90bfeeaeb7ee47aed9297379132a15d640c57bcb8b36da45c63f0437465c38122cbe941b52b7597c
     prepare:
       - |
         tar -xzf grpc-go.tar.gz --strip-components=1


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/blob/3a4d9316aa9e3f0afec58e83ed744b0be4d337fa/CHANGES.txt#L1-L175

https://github.com/grpc/grpc-go/releases/tag/v1.42.0
https://github.com/grpc/grpc-go/releases/tag/v1.41.0
https://github.com/grpc/grpc-go/releases/tag/v1.40.0

Signed-off-by: Alexey Palazhchenko <alexey.palazhchenko@talos-systems.com>