### PR TITLE
chore: bump toolchain to the final 0.4.0 version

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/talos-systems/toolchain:v0.4.0-alpha.0-1-g3d280cf
+  TOOLCHAIN_IMAGE: ghcr.io/talos-systems/toolchain:v0.4.0
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/tools


### PR DESCRIPTION
In preparation for cutting release of tools.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>