### PR TITLE
chore: reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHA ?= $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG ?= $(shell git describe --tag --always --dirty)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
 
 # Sync bldr image with Pkgfile
 BLDR ?= docker run --rm --volume $(PWD):/tools --entrypoint=/bldr \
@@ -17,6 +18,7 @@ DEST ?= _out
 COMMON_ARGS := --file=Pkgfile
 COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
+COMMON_ARGS += --build-arg=SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)
 
 TARGETS = tools
 

--- a/Pkgfile
+++ b/Pkgfile
@@ -1,11 +1,11 @@
-# syntax = ghcr.io/talos-systems/bldr:v0.2.0-alpha.5-frontend
+# syntax = ghcr.io/talos-systems/bldr:v0.2.0-alpha.7-frontend
 
 # Sync bldr image with Makefile
 
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/talos-systems/toolchain:v0.4.0
+  TOOLCHAIN_IMAGE: ghcr.io/talos-systems/toolchain:v0.5.0
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/tools

--- a/meson/pkg.yaml
+++ b/meson/pkg.yaml
@@ -20,6 +20,9 @@ steps:
     install:
       - |
         python3 setup.py install --prefix=/toolchain --root="/rootfs"
+
+        # Determinism: remove all bytecode
+        find /rootfs -type d -name __pycache__ -print0 | xargs -0 -I {} rm -rf "{}"
 finalize:
   - from: /rootfs
     to: /

--- a/openssl/pkg.yaml
+++ b/openssl/pkg.yaml
@@ -8,6 +8,8 @@ steps:
         destination: openssl.tar.gz
         sha256: f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96
         sha512: ba0ef99b321546c13385966e4a607734df38b96f6ed45c4c67063a5f8d1482986855279797a6920d9f86c2ec31ce3e104dcc62c37328caacdd78aec59aa66156
+    env:
+      SOURCE_DATE_EPOCH: "1"
     prepare:
       - |
         mkdir openssl


### PR DESCRIPTION
* use new bldr version with SOURCE_DATE_EPOCH
* fix reproducibility issues in `meson` and `openssl`
* bump toolchain to the latest reproducible 0.5.0

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>